### PR TITLE
Point tree-sitter-jinja2 dep to main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-jinja2"
 version = "0.1.0"
-source = "git+ssh://git@github.com/fishtown-analytics/tree-sitter-jinja2?branch=rust-bindings#3a208bbc068c3e2f0aca6aee5edf65d89eff0287"
+source = "git+ssh://git@github.com/fishtown-analytics/tree-sitter-jinja2?branch=main#4f54210139bd1f7cd34737b3f52bab7bc2922812"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 tree-sitter = "0.19"
-tree-sitter-jinja2 = { git = "ssh://git@github.com/fishtown-analytics/tree-sitter-jinja2", branch = "rust-bindings" }
+tree-sitter-jinja2 = { git = "ssh://git@github.com/fishtown-analytics/tree-sitter-jinja2", branch = "main" }


### PR DESCRIPTION
Now that the tree-sitter-jinja2 repository is public and rust bindings are merged, let's point to the main branch of that project.