### PR TITLE
Python interface fixes

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -1,11 +1,7 @@
 use crate::extractor::{extract_from_source, ConfigVal, Extraction};
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
-use pyo3::types:: {
-    PyDict,
-    PyList,
-    PySet,
-};
+use pyo3::types::{PyDict, PyList, PySet};
 use pyo3::wrap_pyfunction;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -38,14 +34,11 @@ fn pythonize(py: Python, extraction: Extraction) -> PyResult<PyObject> {
             (a, None) => vec![a],
         })
         .collect();
-    let sources: &PySet = 
-        PySet::new(py, &extraction.sources[..])?;
+    let sources: &PySet = PySet::new(py, &extraction.sources[..])?;
     let py_configs: Vec<(String, PyObject)> = extraction
         .configs
         .into_iter()
-        .map(|(k, v)| {
-            (k, convert_config(py, v))
-        })
+        .map(|(k, v)| (k, convert_config(py, v)))
         .collect();
     let configs: &PyList = PyList::new(py, &py_configs[..]);
 


### PR DESCRIPTION
The python types exposed weren't what the old script was passing. It's an oversight on my part but it's an easy fix. 