### PR TITLE
use custom exception

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -74,7 +74,10 @@ pub fn py_extract_from_source(source: &str) -> PyResult<PyObject> {
 }
 
 #[pymodule]
-fn dbt_extractor(_py: Python, m: &PyModule) -> PyResult<()> {
+fn dbt_extractor(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("ExtractionError", py.get_type::<ExtractionError>())
+        .unwrap();
+
     m.add_wrapped(wrap_pyfunction!(py_extract_from_source))
         .unwrap();
 


### PR DESCRIPTION
without a custom exception type, calling code would have to catch everything which is very much bad python practice. This adds the `ExtractionError` type that can be caught more precisely.