### PR TITLE
feat: update GHA to build musllinux wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,142 +9,207 @@ on:
         default: "false"
 
 jobs:
-  python-macos:
-    name: Build macos py${{ matrix.python-version }}
+  macos:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      # This step runs on the GHA vm
-      # Exclude the `--no-sdist` arg for at least 1 python version, no need to build it for each python version
+          python-version: 3.9
+          architecture: x64
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
       - name: Build wheels - x86_64
         uses: messense/maturin-action@v1
         with:
           target: x86_64
-          args: -i python${{ matrix.python-version }} --release --out dist ${{ matrix.python-version != '3.9' && '--no-sdist' || '' }}
-      # This step runs on the GHA vm
+          args: --release --out dist
+      - name: Install built wheel - x86_64
+        run: |
+          pip install dbt-extractor --no-index --find-links dist --force-reinstall
+          python -c "import dbt_extractor"
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
-        env:
-          PYO3_CROSS_LIB_DIR: /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib
         with:
-          args: -i python${{ matrix.python-version }} --release --universal2 --out dist --no-sdist
-      - name: Show wheels generated
-        run: ls -lh dist/
+          args: --release --universal2 --out dist --no-sdist
+      - name: Install built wheel - universal2
+        run: |
+          pip install dbt-extractor --no-index --find-links dist --force-reinstall
+          python -c "import dbt_extractor"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels
           path: dist
 
-  python-windows:
-    name: Build windows ${{ matrix.target }} py${{ matrix.python-version }}
+  windows:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
           architecture: ${{ matrix.target }}
-      # This step runs on the GHA vm
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
       - name: Build wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: -i python --release --out dist --no-sdist
-      - name: Show wheels generated
-        run: ls -lh dist
-        shell: bash
+          args: --release --out dist --no-sdist
+      - name: Install built wheel
+        run: |
+          pip install dbt-extractor --no-index --find-links dist --force-reinstall
+          python -c "import dbt_extractor"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels
           path: dist
 
-  python-linux:
-    name: Build linux ${{ matrix.target }}
+  linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v2
-      # supported python versions
-      # https://github.com/messense/maturin-action/blob/51478586be5dfb16a569cb6bbec182fba9f13f79/src/index.ts#L245
-      # this step runs in a docker container selected by the messense/maturin-action action
-      # there is no need to install python on the GHA vm
-      - name: Build Wheels
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Build wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --out dist --no-sdist
-      - name: Show wheels generated
-        run: ls -lh dist/
+      - name: Install built wheel
+        if: matrix.target == 'x86_64'
+        run: |
+          pip install dbt-extractor --no-index --find-links dist --force-reinstall
+          python -c "import dbt_extractor"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels
           path: dist
 
-  python-linux-cross:
-    name: Build py${{ matrix.python.version }} linux-cross ${{ matrix.target }}
+  linux-cross:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-          [
-            { version: "3.6", abi: "cp36-cp36m" },
-            { version: "3.7", abi: "cp37-cp37m" },
-            { version: "3.8", abi: "cp38-cp38" },
-            { version: "3.9", abi: "cp39-cp39" },
-          ]
         target: [aarch64, armv7, s390x, ppc64le, ppc64]
-    env:
-      PYO3_CROSS_LIB_DIR: /opt/python/${{ matrix.python.abi }}/lib
     steps:
       - uses: actions/checkout@v2
-      # this step runs in a docker container selected by the messense/maturin-action action
-      # there is no need to install python on the GHA vm
-      - name: Build Wheels
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Build wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: -i python${{ matrix.python.version }} --release --out dist --no-sdist
+          args: --release --out dist --no-sdist
       - uses: uraimo/run-on-arch-action@v2.0.5
         if: matrix.target != 'ppc64'
         name: Install built wheel
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu20.04
+          distro: ubuntu18.04
           githubToken: ${{ github.token }}
-          # Mount the dist directory as /artifacts in the container
-          dockerRunArgs: |
-            --volume "${PWD}/dist:/artifacts"
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip software-properties-common
-            add-apt-repository ppa:deadsnakes/ppa
-            apt-get update
-            apt-get install -y python3.6 python3.7 python3.8 python3.9
+            apt-get install -y --no-install-recommends python3 python3-pip
+            pip3 install -U pip
           run: |
-            ls -lrth /artifacts
-            PYTHON=python${{ matrix.python.version }}
-            $PYTHON -m pip install -U pip
-            $PYTHON -m pip install dbt_extractor --no-index --find-links /artifacts --force-reinstall
-            $PYTHON -c 'import dbt_extractor'
-      - name: Show wheels generated
-        run: ls -lh dist/
+            pip3 install dbt-extractor --no-index --find-links dist/ --force-reinstall
+            python3 -c "import dbt_extractor"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  musllinux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - i686-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist --no-sdist
+      - name: Install built wheel
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: alpine:latest
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            apk add py3-pip
+            pip3 install -U pip
+            pip3 install dbt-extractor --no-index --find-links /io/dist/ --force-reinstall
+            python3 -c "import dbt_extractor"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  musllinux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-musl
+            arch: aarch64
+          - target: armv7-unknown-linux-musleabihf
+            arch: armv7
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist --no-sdist
+      - uses: uraimo/run-on-arch-action@master
+        name: Install built wheel
+        with:
+          arch: ${{ matrix.platform.arch }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add py3-pip
+            pip3 install -U pip
+          run: |
+            pip3 install dbt-extractor --no-index --find-links dist/ --force-reinstall
+            python3 -c "import dbt_extractor"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -152,7 +217,7 @@ jobs:
           path: dist
 
   publish:
-    needs: [python-macos, python-windows, python-linux, python-linux-cross]
+    needs: [macos, windows, linux, linux-cross, musllinux, musllinux-cross]
     name: Publish to PyPI
     environment:
       name: pypi-prod

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 description = "A tool to analyze and extract information from Jinja used in dbt projects."
 authors = [
   "Nathaniel May <nathaniel.may@dbtlabs.com>",
-  "dbt Labs <info@dbtlabs.com>"
+  "dbt Labs <info@dbtlabs.com>",
 ]
 edition = "2018"
 homepage = "https://github.com/dbt-labs/dbt-parser-generator/"
@@ -17,7 +17,7 @@ name = "dbt_extractor"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-pyo3 = { version = "0.15.1", features = ["extension-module"] }
+pyo3 = { version = "0.15.1", features = ["abi3-py36", "extension-module"] }
 rayon = "1.5.1"
 tree-sitter = "0.19"
 tree-sitter-jinja2 = { git = "https://github.com/dbt-labs/tree-sitter-jinja2", tag = "v0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "dbt_extractor"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-pyo3 = { version = "0.15.1", features = ["abi3-py36", "extension-module"] }
+pyo3 = { version = "0.15.1", features = ["abi3-py37", "extension-module"] }
 rayon = "1.5.1"
 tree-sitter = "0.19"
 tree-sitter-jinja2 = { git = "https://github.com/dbt-labs/tree-sitter-jinja2", tag = "v0.1.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,27 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"
 
 [project]
 name = "dbt-extractor"
 authors = [
-  {email = "info@dbtlabs.com"},
-  {name = "dbt Labs"},
-  {email = "nathaniel.may@dbtlabs.com"},
-  {name = "Nathaniel May"}
+  { email = "info@dbtlabs.com" },
+  { name = "dbt Labs" },
+  { email = "nathaniel.may@dbtlabs.com" },
+  { name = "Nathaniel May" },
 ]
 long_description = { file = "README.md" }
 long_description_content_type = "text/markdown"
 readme = "README.md"
 requires-python = ">=3.6.1"
 classifiers = [
-    "Programming Language :: Rust",
+  "Programming Language :: Rust",
 
-    "Development Status :: 5 - Production/Stable",
+  "Development Status :: 5 - Production/Stable",
 
-    "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: Apache Software License",
 
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: POSIX :: Linux",
 ]


### PR DESCRIPTION
This PR does a few things:
- Enables the `abi-py36` feature for PyO3 ([docs](https://pyo3.rs/v0.15.1/features.html#the-abi3-pyxy-features)). This allows wheels to be compatible with multiple python versions. We only need to distribute 1 wheel per platform with this change.
- Adds additional steps to the release workflow to build wheels for musllinux platforms (allows folks to install dbt in Alpine linux images)
- update maturin, the pyo3 build tool, to latest stable version