### PR TITLE
Revise GitHub Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist --no-sdist
+          args: --release --universal2 --out dist
       - name: Install built wheel - universal2
         run: |
           pip install dbt-extractor --no-index --find-links dist --force-reinstall
@@ -67,7 +67,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist
+          args: --release --out dist
       - name: Install built wheel
         run: |
           pip install dbt-extractor --no-index --find-links dist --force-reinstall
@@ -94,7 +94,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist --no-sdist
+          args: --release --out dist
       - name: Install built wheel
         if: matrix.target == 'x86_64'
         run: |
@@ -121,7 +121,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist --no-sdist
+          args: --release --out dist
       - uses: uraimo/run-on-arch-action@v2.5.0
         if: matrix.target != 'ppc64'
         name: Install built wheel
@@ -160,7 +160,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-sdist
+          args: --release --out dist
       - name: Install built wheel
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: addnab/docker-run-action@v3
@@ -197,7 +197,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-sdist
+          args: --release --out dist
       - uses: uraimo/run-on-arch-action@v2.5.0
         name: Install built wheel
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64, armv7, s390x, ppc64le, ppc64]
+        target: [aarch64, armv7, ppc64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist
+          args: --release --universal2-apple-darwin --out dist
       - name: Install built wheel - universal2
         run: |
           pip install dbt-extractor --no-index --find-links dist --force-reinstall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64, armv7, ppc64]
+        target: [aarch64, armv7, s390x, ppc64le, ppc64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2-apple-darwin --out dist
-      - name: Install built wheel - universal2
+          args: --release --out dist
+      - name: Install built wheel
         run: |
           pip install dbt-extractor --no-index --find-links dist --force-reinstall
           python -c "import dbt_extractor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --out dist
-      - name: Install built wheel
+          args: --release --target universal2-apple-darwin --out dist
+      - name: Install built wheel - universal2
         run: |
           pip install dbt-extractor --no-index --find-links dist --force-reinstall
           python -c "import dbt_extractor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         name: Install built wheel
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu18.04
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
           install: |
             apt-get update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=1.1,<1.2"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
This PR changes the release workflow:

- Moves us to maturin 1.1 to work around issues building on more recent versions of macos
- Changes several arguments to maturin to reflect changes int its cli
- Updates to a reasonably recent version of Ubuntu during cross-architecture builds and test installs, in order to work around issues which had arisen using Ubuntu 18