### PR TITLE
Generate an sdist for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
   macos:
     runs-on: macos-latest
@@ -70,7 +70,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   windows:
@@ -102,7 +102,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   linux:
@@ -130,7 +130,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   linux-cross:
@@ -166,7 +166,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   musllinux:
@@ -202,7 +202,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   musllinux-cross:
@@ -240,7 +240,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
 
   publish:
@@ -255,9 +255,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: wheels
+          name: for-pypi
           path: dist
-      - name: Show wheels generated
+      - name: Show distributions generated
         run: ls -lh dist
       - uses: actions/setup-python@v4
       - name: Publish package distributions to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,33 @@ on:
         default: "false"
 
 jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Build sdist
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --sdist --out dist
+      - name: Install built sdist
+        if: matrix.target == 'x86_64'
+        run: |
+          pip install dist/*.tar.gz --force-reinstall
+          python -c "import dbt_extractor"
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
   macos:
     runs-on: macos-latest
     steps:
@@ -217,7 +244,7 @@ jobs:
           path: dist
 
   publish:
-    needs: [macos, windows, linux, linux-cross, musllinux, musllinux-cross]
+    needs: [sdist, macos, windows, linux, linux-cross, musllinux, musllinux-cross]
     name: Publish to PyPI
     environment:
       name: pypiprod

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo/target/
 # python
 dist/
 env/
+__pycache__/


### PR DESCRIPTION
Closes #71

I don't understand all the context about the decision to remove sdists, but I found this: https://github.com/dbt-labs/dbt-extractor/pull/68#pullrequestreview-1540153858. The file is only 266 kb, and there's only one for all platforms, so I see zero risk of any "clogging".

Fixing this would really help people using conda-forge, Anaconda, and Linux distro packagers.

On the side I added `__pycache__` to `.gitignore`.