### PR TITLE
Add CI support for building and releasing Window ARM64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,42 @@ jobs:
           name: windows-${{ matrix.target }}-wheels
           path: dist
 
+  windows-arm64:
+    runs-on: windows-11-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: arm64
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # PyO3/maturin-action@v1
+        with:
+          target: aarch64
+          args: --release --out dist
+
+      - name: Install built wheel
+        run: |
+          pip install dbt-extractor --no-index --find-links dist --force-reinstall
+          python -c "import dbt_extractor"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # actions/upload-artifact@v5
+        with:
+          name: windows-arm64-wheels
+          path: dist
+
   linux:
     runs-on: ubuntu-latest
     strategy:
@@ -219,7 +255,7 @@ jobs:
 
   publish-test:
     if: ${{ github.event.inputs.publish != 'true' }}
-    needs: [macos, windows, linux, linux-cross, musllinux, musllinux-cross]
+    needs: [macos, windows, windows-arm64, linux, linux-cross, musllinux, musllinux-cross]
     name: Publish to PyPI Test
     environment:
       name: pypitest
@@ -248,7 +284,7 @@ jobs:
 
   publish-prod:
     if: ${{ github.event.inputs.publish == 'true' }}
-    needs: [macos, windows, linux, linux-cross, musllinux, musllinux-cross]
+    needs: [macos, windows, windows-arm64, linux, linux-cross, musllinux, musllinux-cross]
     name: Publish to PyPI
     environment:
       name: pypiprod


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
* The PR adds support for building and testing dbt-extractor Windows ARM64 wheels
* Modified the release workflow file to include Windows ARM64 build configuration[[release.yml](https://github.com/dbt-labs/dbt-extractor/compare/main...MugundanMCW:dbt-extractor:main#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)]
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
